### PR TITLE
Fix JSON payload in push restore example

### DIFF
--- a/pushRestore.sh
+++ b/pushRestore.sh
@@ -288,7 +288,7 @@ DATA='{
 	"numFiles":1,
 	"showDeleted":true,
 	"restoreFullPath":true,
-	"timestamp":'${restoreDateEpochMS}'
+	"timestamp":'${restoreDateEpochMS}',
 	"pushRestoreStrategy":'${pushRestoreStrategy}',
 	"permitRestoreToDifferentOsVersion":'${permitRestoreToDifferentOsVersion}',
 	"existingFiles":'${existingFiles}',


### PR DESCRIPTION
A missing comma caused the JSON payload for POSTing to PushRestoreJob to
be malformed.